### PR TITLE
Add dark/light mode in header when user not connected

### DIFF
--- a/src/components/Form/FormFieldWithButton.vue
+++ b/src/components/Form/FormFieldWithButton.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import {computed} from "vue";
+
+import ErrorMessage from "@/components/Utils/ErrorMessage.vue";
+import FormField from "./FormField.vue";
+
+
+const props = defineProps<{
+	modelValue?: string
+	label: string
+	type?: string
+	placeholder?: string
+	error?: string
+	disabled?: boolean
+	buttonText: string
+}>();
+
+const emit = defineEmits<{
+	(event: 'update:modelValue', val: string): void
+	(event: 'change', ev: Event): void
+	(event: 'click', ev: MouseEvent): void   
+}>()
+
+const inputValue = computed({
+	get: () => props.modelValue,
+	set: (val: string) => emit('update:modelValue', val)
+})
+
+function onChange (e:Event) {
+	emit('change', e)
+}
+
+function onClick(e: MouseEvent) {
+  emit('click', e)
+}
+
+</script>
+
+<template>
+	<div class="flex">
+		<FormField v-model="inputValue" :label :type="type" :placeholder="placeholder" :error="error" @change="onChange"></FormField>
+		<button :disabled="disabled"
+				@click="onClick"
+				class="px-4 py-2 rounded-xl bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-400 h-[42px] self-end">
+					{{ buttonText }}</button>
+	</div>
+</template>
+

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -47,7 +47,7 @@ const go = (path: string) => {
 					</button>
 					<DropDown v-model="openDropDownProfileMenu" width-class="w-32">
 						<template #trigger>
-							<button class="w-[40px] h-[40px] rounded-full bg-cover cursor-pointer"
+							<button class="w-[40px] h-[40px] rounded-full bg-cover cursor-pointer stranslate-y-[2px]"
 									:style="{ backgroundImage: `url(/api/users/${authStore.userId}/avatar)`, backgroundSize: `cover`, backgroundPosition: `center` }">
 							</button>
 						</template>
@@ -66,7 +66,12 @@ const go = (path: string) => {
 						</template>
 					</DropDown>
 				</div>
-                <div v-else>
+                <div v-else class="flex flex-row space-x-2">
+					<button
+						@click="toggle"
+						class="text-[#1A1F36] dark:text-gray-100 px-5 py-2 inline-block rounded-lg text-xs uppercase shadow-sm cursor-pointer border font-bold">
+						{{ theme === 'light' ? '🌙' : '☀️' }}
+					</button>
 					<button
 						@click="modelValue = true"
 						class="text-[#1A1F36] dark:text-gray-100 px-5 py-2 inline-block rounded-lg text-xs uppercase shadow-sm cursor-pointer border font-semibold">

--- a/src/components/Tournament.vue
+++ b/src/components/Tournament.vue
@@ -3,8 +3,11 @@ import { ref, onMounted, watch, computed } from 'vue'
 import { useTournament } from '@/store/tournament'
 import { useAuth } from '@/store/auth';
 import { useLang } from '@/composables/useLang';
+
 import Modal from "@/components/Modal/Modal.vue";
 import ErrorMessage from "@/components/Utils/ErrorMessage.vue";
+import FormField from './Form/FormField.vue';
+import FormFieldWithButton from './Form/FormFieldWithButton.vue';
 
 const newPlayer = ref('')
 const players = ref<string[]>([])
@@ -79,62 +82,48 @@ onMounted(async() => {
 <template>
 	<Modal v-model="modalValue" title="Tournament">
 
-    <div class="flex flex-col items-center p-4 gap-4 max-w-md mx-auto dark:text-white">
-    <h1 class="text-2xl font-bold">{{ $t('tournament.create') }}</h1>
+		<div class="flex flex-col items-center p-4 gap-4 max-w-md mx-auto dark:text-white">
+			<h1 class="text-2xl font-bold">{{ $t('tournament.create') }}</h1>
 
-    <div class="w-full">
-        <label class="block text-sm font-medium text-gray-700 dark:text-gray-200">{{ $t('tournament.name') }}</label>
-        <input
-        v-model="newPlayer"
-        type="text"
-        class="mt-1 w-full rounded-lg border px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-900"
-        :placeholder="$t('tournament.addPlayer')"
-        />
-    </div>
+			<FormFieldWithButton type="text" v-model="newPlayer" :label="$t('tournament.name')" :placeholder="$t('tournament.addPlayer')" :button-text="$t('tournament.add')" :disabled="players.length >= 32" @click="addPlayer"></FormFieldWithButton>
 
-    <button :disabled="players.length >= 32"
-        @click="addPlayer"
-        class="px-4 py-2 rounded-xl bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-400">
-        {{ $t('tournament.add') }}
-    </button>
+			<p class="text-sm text-gray-600">
+				{{ players.length }} {{$t('tournament.player')}}{{ players.length > 1 ? 's' : '' }}
+			</p>
 
-    <p class="text-sm text-gray-600">
-        {{ players.length }} {{$t('tournament.player')}}{{ players.length > 1 ? 's' : '' }}
-    </p>
+			<ul class="w-full divide-y divide-gray-200 bg-white rounded-lg shadow max-h-64 overflow-y-auto dark:text-black">
+				<li
+					v-for="(player, index) in players"
+					:key="index"
+					class="flex justify-between px-4 py-2">
+					<span class="truncate">{{ player }}</span>
+					<button v-if="index != 0" @click="removePlayer(index)" class="text-red-500 hover:underline">{{$t('tournament.delete')}}</button>
+				</li>
+			</ul>
 
-    <ul class="w-full divide-y divide-gray-200 bg-white rounded-lg shadow max-h-64 overflow-y-auto dark:text-black">
-        <li
-        v-for="(player, index) in players"
-        :key="index"
-        class="flex justify-between px-4 py-2">
-        <span>{{ player }}</span>
-        <button v-if="index != 0" @click="removePlayer(index)" class="text-red-500 hover:underline">{{$t('tournament.delete')}}</button>
-        </li>
-    </ul>
+			<button
+				:disabled="![4, 8, 16, 32].includes(players.length)"
+				@click="startTournament"
+				class="mt-4 px-6 py-2 rounded-xl bg-green-600 text-white hover:bg-green-700 disabled:bg-gray-400">
+				{{$t('tournament.createTournament')}}
+			</button>
 
-    <button
-        :disabled="![4, 8, 16, 32].includes(players.length)"
-        @click="startTournament"
-        class="mt-4 px-6 py-2 rounded-xl bg-green-600 text-white hover:bg-green-700 disabled:bg-gray-400">
-        {{$t('tournament.createTournament')}}
-    </button>
+				<div v-if="players.length !== 0 && ![4, 8, 16, 32].includes(players.length)">
+					<ErrorMessage error="tournament.required"></ErrorMessage>
+				</div>
 
-		<div v-if="players.length !== 0 && ![4, 8, 16, 32].includes(players.length)">
-			<ErrorMessage error="tournament.required"></ErrorMessage>
+			<div>
+				<div class="space-y-2">
+				<label class="flex justify-between text-sm">
+					{{$t('pong.ballSpeed')}}
+					<input type="range" v-model.number="localCheats.ballSpeed" min="1" max="15" step="0.1" class="mx-2 w-20">
+				</label>
+				<label class="flex justify-between text-sm">
+					{{$t('pong.paddleSpeed')}}
+					<input type="range" v-model.number="localCheats.paddleSpeed" min="1" max="40" step="0.1" class="mx-2 w-20">
+				</label>
+				</div>
+			</div>
 		</div>
-
-    <div>
-        <div class="space-y-2">
-        <label class="flex justify-between text-sm">
-            {{$t('pong.ballSpeed')}}
-            <input type="range" v-model.number="localCheats.ballSpeed" min="1" max="15" step="0.1" class="mx-2 w-20">
-        </label>
-        <label class="flex justify-between text-sm">
-            {{$t('pong.paddleSpeed')}}
-            <input type="range" v-model.number="localCheats.paddleSpeed" min="1" max="40" step="0.1" class="mx-2 w-20">
-        </label>
-        </div>
-    </div>
-    </div>
     </Modal>
 </template>

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -4,12 +4,12 @@ import { useLang } from "@/composables/useLang"
 import {useAuth} from "@/store/auth.ts";
 import { useRouter } from "vue-router";
 
-import CTAButton from "@/components/CallToActionButton.vue";
 import AuthModal from "@/components/Modal/AuthModal/AuthModal.vue";
 
 const authStore = useAuth()
 const router = useRouter()
 const { t } = useLang()
+
 const showAuthModal = ref<boolean>(false)
 
 function onClickCTA() {

--- a/src/views/Pong.vue
+++ b/src/views/Pong.vue
@@ -589,10 +589,8 @@ const gameLoop = () => {
 			</div>
 			<button @click="showSettings = true" class="text-black py-3 md:px-4 bg-[#fff] rounded-md text-lg">Settings</button>
 		</div>
-        <div v-if="showTournament || showNextMatch" class="absolute z-10 bg-white p-6 rounded-xl shadow-lg w-[90%] max-w-xl h-auto top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
-            <Tournament v-if="showTournament" v-model:visible="showTournament" v-model:nextMatch="showNextMatch" v-model:gameMode="gameMode" @playTournament="playTournamentGame"></Tournament>
-            <TournamentNext v-if="showNextMatch" v-model:visible="showNextMatch" v-model:gameMode="gameMode" v-model:restart="showTournament"></TournamentNext>
-        </div>
+		<Tournament v-if="showTournament" v-model:visible="showTournament" v-model:nextMatch="showNextMatch" v-model:gameMode="gameMode" @playTournament="playTournamentGame"></Tournament>
+		<TournamentNext v-if="showNextMatch" v-model:visible="showNextMatch" v-model:gameMode="gameMode" v-model:restart="showTournament"></TournamentNext>
 		<div class=" bg-gray-800 w-[95%] h-full">
 			<canvas ref="pongCanvas" class="w-full h-full"></canvas>
 		</div>


### PR DESCRIPTION
This pull request introduces several enhancements and refactors across multiple components, focusing on improving usability, code organization, and UI consistency. The most significant changes include the addition of a new reusable `FormFieldWithButton` component, updates to the `Tournament` component to utilize this new component, and minor UI adjustments in various files.

### Component Enhancements:
* **`FormFieldWithButton.vue`**: Introduced a new reusable component that combines a form field with an associated button. This component simplifies handling inputs and actions together, improving code maintainability.
* **`Tournament.vue`**: Refactored to use the new `FormFieldWithButton` component for adding players, replacing the previous manual setup of input and button elements. This change enhances readability and consistency.

### UI Improvements:
* **`Tournament.vue`**: Modified the player list to truncate long names for better visual alignment and usability.
* **`Header.vue`**: Added a theme toggle button with icons for light and dark modes and adjusted the avatar button styling with `translate-y` for improved alignment. [[1]](diffhunk://#diff-c970699f851dadc4a40a1c2a7b29886d5da454125e84e387a8d0abfa8b63be85L69-R74) [[2]](diffhunk://#diff-c970699f851dadc4a40a1c2a7b29886d5da454125e84e387a8d0abfa8b63be85L50-R50)

### Code Cleanup:
* **`LandingPage.vue`**: Removed an unused import (`CTAButton`) to streamline the code.
* **`Pong.vue`**: Removed redundant wrapper divs around tournament-related components to simplify the structure.