### PR TITLE
Update settings color value is now reactive

### DIFF
--- a/src/components/PongSettings.vue
+++ b/src/components/PongSettings.vue
@@ -126,8 +126,8 @@ onMounted(() => {
 	drawPreview()
 })
 
-const apply = () => {
-    setSettings()
+const apply = async () => {
+    await setSettings()
     emit('set')
 	emit('update:visible', false)
 }

--- a/src/views/Pong.vue
+++ b/src/views/Pong.vue
@@ -8,6 +8,7 @@ import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useTournament } from '@/store/tournament'
 import { useAuth } from '@/store/auth'
 import axios from 'axios'
+import { forEachTrailingCommentRange } from 'typescript'
 
 const pongCanvas = ref<HTMLCanvasElement | null>(null)
 const ctx = ref<CanvasRenderingContext2D | null>(null)
@@ -64,8 +65,9 @@ const showModeSettings = ref(false)
 const modeSettingsMode = ref<'solo' | 'multi' | 'tournament' | null>(null)
 const cheats =ref({ ballSpeed: ballSpeed, paddleSpeed: basePlayerSpeed })
 
-watch(settings, () => {
-	nextTick(render)
+watch(() => settings, async () => {
+	await nextTick()
+	render()
 }, { deep: true })
 
 const updateCanvasDimensions = () => {
@@ -86,19 +88,38 @@ const updateCanvasDimensions = () => {
 	}
 }
 
-const getSettings = async() => {
+async function getSettings() {
+  try {
     const response = await axios.get(`/api/users/${authStore.userId}/settings`)
     const data = response.data
-    if (data.background != 'default')
-        settings.value.background = data.background
-    if (data.paddle != 'default')
-        settings.value.paddle = data.paddle
-    if (data.score != 'default')
-        settings.value.score = data.score
-    if (data.divider != 'default')
-        settings.value.divider = data.divider
-    if (data.ball != 'default')
-        settings.value.ball = data.ball
+
+    let hasChanged = false
+    if (data.background !== 'default') {
+      settings.value.background = data.background
+      hasChanged = true
+    }
+    if (data.paddle !== 'default') {
+      settings.value.paddle = data.paddle
+      hasChanged = true
+    }
+    if (data.score !== 'default') {
+      settings.value.score = data.score
+      hasChanged = true
+    }
+    if (data.divider !== 'default') {
+      settings.value.divider = data.divider
+      hasChanged = true
+    }
+    if (data.ball !== 'default') {
+      settings.value.ball = data.ball
+      hasChanged = true
+    }
+    if (!hasChanged) {
+      settings.value = { ...settings.value }
+    }
+  } catch (error) {
+    console.error("Error with get Settings :", error)
+  }
 }
 
 onMounted(() => {


### PR DESCRIPTION
This pull request introduces several improvements to the `Pong` application, focusing on asynchronous operations, error handling, and code readability. The most important changes include converting functions to asynchronous, enhancing error handling in settings retrieval, and improving the reactivity of the `settings` watcher.

### Asynchronous Operations and Error Handling

* [`src/components/PongSettings.vue`](diffhunk://#diff-004a3926c1201e2bd27d42c36a63f5109b27ca700c57d03515585354c2393f75L129-R130): Updated the `apply` function to be asynchronous, ensuring `setSettings` completes before emitting events.
* [`src/views/Pong.vue`](diffhunk://#diff-aba8a74ce4b627a43da88809745d6bdd82ac1a4a029d73dabe8ec5e63c6a87bbL89-R122): Refactored the `getSettings` function to include robust error handling with a `try-catch` block, preventing crashes when API requests fail. Added a `hasChanged` flag to optimize settings updates.

### Reactive Updates and Code Improvements

* [`src/views/Pong.vue`](diffhunk://#diff-aba8a74ce4b627a43da88809745d6bdd82ac1a4a029d73dabe8ec5e63c6a87bbL67-R70): Modified the `watch` function for `settings` to use an arrow function and await `nextTick` before calling `render`, ensuring reactivity and smoother updates.

### Miscellaneous

* [`src/views/Pong.vue`](diffhunk://#diff-aba8a74ce4b627a43da88809745d6bdd82ac1a4a029d73dabe8ec5e63c6a87bbR11): Added an unused import statement for `forEachTrailingCommentRange` from `typescript`, which appears unnecessary and may need removal in future revisions.